### PR TITLE
Fix EditableSpan component functionality for reward's price.

### DIFF
--- a/src/app/components/EditableSpan.tsx
+++ b/src/app/components/EditableSpan.tsx
@@ -1,9 +1,11 @@
 import React, {ChangeEvent, useState} from 'react';
 import {TextField} from '@mui/material';
+import {isNumber} from "node:util";
 
 type EditableSpanPropsType = {
     title: string;
     onChange: (newValue: string, rewardListId?: string) => void;
+    numberSpan?: boolean;
 };
 
 export const EditableSpan = React.memo((props: EditableSpanPropsType) => {
@@ -19,8 +21,20 @@ export const EditableSpan = React.memo((props: EditableSpanPropsType) => {
         props.onChange(title);
     };
 
+    //A regular expression that includes only numbers from 0 to 9
+    const regExpForNumbers = new RegExp("^[0-9]*$");
+
     const handleOnChangeTitle = (e: ChangeEvent<HTMLInputElement>) => {
-        setTitle(e.currentTarget.value);
+        if (props.numberSpan) {
+            setTitle(e.currentTarget.value.replace(/[^\d.]/ig, ""));
+            if (e.currentTarget.value === "") setTitle(`${0}`);
+            if (e.currentTarget.value.charAt(0) === '0' && e.currentTarget.value.length > 1 && (e.currentTarget.value.charAt(1)).match(regExpForNumbers)) {
+                setTitle(e.currentTarget.value.charAt(0)
+                    .replace('0', e.currentTarget.value.charAt(1)));
+            }
+        } else {
+            setTitle(e.currentTarget.value);
+        }
     };
 
     return editMode ? (

--- a/src/app/components/Reward.tsx
+++ b/src/app/components/Reward.tsx
@@ -1,10 +1,9 @@
-import React, {ChangeEvent, memo, MouseEvent, useCallback} from 'react';
+import React, {memo, MouseEvent, useCallback} from 'react';
 import {IconButton, Paper} from '@mui/material';
 import {EditableSpan} from './EditableSpan';
-import {CurrencyExchange, CurrencyYuan, Delete} from '@mui/icons-material';
+import {CurrencyYuan, Delete} from '@mui/icons-material';
 import {RewardType} from "../features/Rewards/RewardsContainer";
 import {useSortable} from "@dnd-kit/sortable";
-import {changeRewardPrice} from "../features/Rewards/rewardsSlice";
 
 type RewardPropsType = {
     reward: RewardType;
@@ -64,7 +63,7 @@ const Reward = (props: RewardPropsType) => {
         >
             <div style={{display: 'flex', alignItems: 'center', gap: '10px'}}>
                 <Paper style={{padding: '1px', background: '#FFEEEE'}}>
-                    <EditableSpan title={`${props.price}`} onChange={onChangePriceHandler} />
+                    <EditableSpan title={`${props.price}`} onChange={onChangePriceHandler} numberSpan={true}/>
                     <IconButton onClick={(e) => onRemoveHandler(e)}>
                         <CurrencyYuan/>
                     </IconButton>


### PR DESCRIPTION
# Fix EditableSpan functionality for price.

Now a parent component also passes an optional parameter "numberSpan". `numberSpan?: boolean;`
The onChangeTitleHandler checks if this prop is passed, if so, it invokes a series of conditional statements and returns the formatted string with only numbers inside of it.

* [x] User can input only numbers. 
    > This is made by comparing the field value to a regular expression.
* [x] The first char can't be an empty string, it converts to 0.
* [x] If the first char is 0 and the second is a number it removes 0 from the start.
